### PR TITLE
Refactoring structures/..

### DIFF
--- a/brainatlas_api/core.py
+++ b/brainatlas_api/core.py
@@ -188,8 +188,6 @@ class Atlas:
     def get_structure_parent(self, acronyms):
         pass
 
-    
-
     # # functions to create oriented planes that can be used to slice actors etc
     # def get_plane_at_point(self, pos, norm, sx, sy,
     #                        color='lightgray', alpha=.25,

--- a/brainatlas_api/core.py
+++ b/brainatlas_api/core.py
@@ -1,8 +1,6 @@
 import numpy as np
 from pathlib import Path
 
-from treelib import Tree
-
 from brainatlas_api.utils import open_json, read_tiff, make_hemispheres_stack
 from brainatlas_api.structures.structure_tree import StructureTree
 from brainatlas_api.obj_utils import read_obj
@@ -190,66 +188,7 @@ class Atlas:
     def get_structure_parent(self, acronyms):
         pass
 
-    def print_structures(self):
-        """ 
-        Prints the name of every structure in the structure tree to the console.
-        """
-        acronyms, names = self.structures_acronyms, self.structures_names
-        sort_idx = np.argsort(acronyms)
-        acronyms, names = (
-            np.array(acronyms)[sort_idx],
-            np.array(names)[sort_idx],
-        )
-        [print("({}) - {}".format(a, n)) for a, n in zip(acronyms, names)]
-
-    def print_structures_tree(self, to_file=False, save_filepath=None):
-        """
-            Prints a 'tree' graph with the hierarchical organisation of all structures
-
-            :param to_file: bool, default False. If True the tree structure is saved to 
-                a file (at save_filepath) instead of printd to REPL
-            :param save_filepath: str, if to_file = True, pass the path to a .txt file 
-                where the tree structure will be saved.
-        """
-
-        def add_descendants_to_tree(atlas, tree, structure_id, parent_id):
-            """
-                Recursively goes through all the the descendants of a region and adds them to the tree
-            """
-            tree.create_node(
-                tag=atlas.id_to_acronym_map[structure_id],
-                identifier=structure_id,
-                parent=parent_id,
-            )
-            descendants = atlas.structures.child_ids([structure_id])[0]
-
-            if len(descendants):
-                for child in descendants:
-                    add_descendants_to_tree(atlas, tree, child, structure_id)
-
-        # Create a Tree structure and initialise with root
-        root = self.acronym_to_id_map["root"]
-        tree = Tree()
-        tree.create_node(tag="root", identifier=root)
-
-        # Recursively iterate through hierarchy#
-        for child in self.structures.child_ids([root])[0]:
-            add_descendants_to_tree(self, tree, child, root)
-
-        if not to_file:
-            tree.show()
-        else:
-            if save_filepath is None:
-                raise ValueError(
-                    "If setting to_file as True, you need to pass the path to \
-                                            a .txt file where the tree will be saved"
-                )
-            elif not save_filepath.endswith(".txt"):
-                raise ValueError(
-                    f"save_filepath should point to a .txt file, not: {save_filepath}"
-                )
-
-            tree.save2file(save_filepath)
+    
 
     # # functions to create oriented planes that can be used to slice actors etc
     # def get_plane_at_point(self, pos, norm, sx, sy,

--- a/brainatlas_api/structures/simple_tree.py
+++ b/brainatlas_api/structures/simple_tree.py
@@ -38,8 +38,6 @@ import operator as op
 from collections import defaultdict
 from six import iteritems
 
-from allensdk.deprecated import deprecated
-
 
 class SimpleTree(object):
     def __init__(self, nodes, node_id_cb, parent_id_cb):
@@ -180,10 +178,6 @@ class SimpleTree(object):
 
         return list(self._nodes)
 
-    @deprecated("Use SimpleTree.parent_ids instead.")
-    def parent_id(self, node_ids):
-        return self.parent_ids(node_ids)
-
     def parent_ids(self, node_ids):
         """Obtain the ids of one or more nodes' parents
         
@@ -296,10 +290,6 @@ class SimpleTree(object):
             out.append(current)
         return out
 
-    @deprecated("Use SimpleTree.nodes instead")
-    def node(self, node_ids=None):
-        return self.nodes(node_ids)
-
     def nodes(self, node_ids=None):
         """Get one or more nodes' full dictionaries from their ids.
         
@@ -324,10 +314,6 @@ class SimpleTree(object):
             ]
         else:
             return self._nodes[node_ids] if node_ids in self._nodes else None
-
-    @deprecated("Use SimpleTree.parents instead")
-    def parent(self, node_ids):
-        return self.parents(node_ids)
 
     def parents(self, node_ids):
         """Get one or mode nodes' parent nodes

--- a/brainatlas_api/structures/simple_tree.py
+++ b/brainatlas_api/structures/simple_tree.py
@@ -197,7 +197,6 @@ class SimpleTree(object):
         else:
             return self._parent_ids[node_ids]
 
-
     def child_ids(self, node_ids):
         """Obtain the ids of one or more nodes' children
         

--- a/brainatlas_api/structures/simple_tree.py
+++ b/brainatlas_api/structures/simple_tree.py
@@ -198,8 +198,11 @@ class SimpleTree(object):
             Items are ids of input nodes' parents in order.
         
         """
+        if isinstance(node_ids, list):
+            return [self._parent_ids[nid] for nid in node_ids]
+        else:
+            return self._parent_ids[node_ids]
 
-        return [self._parent_ids[nid] for nid in node_ids]
 
     def child_ids(self, node_ids):
         """Obtain the ids of one or more nodes' children
@@ -215,8 +218,10 @@ class SimpleTree(object):
             Items are lists of input nodes' children's ids.
             
         """
-
-        return [self._child_ids[nid] for nid in node_ids]
+        if isinstance(node_ids, list):
+            return [self._child_ids[nid] for nid in node_ids]
+        else:
+            return self._child_ids[node_ids]
 
     def ancestor_ids(self, node_ids):
         """Obtain the ids of one or more nodes' ancestors
@@ -312,10 +317,13 @@ class SimpleTree(object):
         if node_ids is None:
             node_ids = self.node_ids()
 
-        return [
-            self._nodes[nid] if nid in self._nodes else None
-            for nid in node_ids
-        ]
+        if isinstance(node_ids, list):
+            return [
+                self._nodes[nid] if nid in self._nodes else None
+                for nid in node_ids
+            ]
+        else:
+            return self._nodes[node_ids] if node_ids in self._nodes else None
 
     @deprecated("Use SimpleTree.parents instead")
     def parent(self, node_ids):
@@ -335,8 +343,10 @@ class SimpleTree(object):
             Items are parents of nodes corresponding to argued ids.
     
         """
-
-        return self.nodes([self._parent_ids[nid] for nid in node_ids])
+        if isinstance(node_ids, list):
+            return self.nodes([self._parent_ids[nid] for nid in node_ids])
+        else:
+            return self.nodes(self._parent_ids[node_ids])
 
     def children(self, node_ids):
         """Get one or mode nodes' child nodes

--- a/brainatlas_api/structures/structure_tree.py
+++ b/brainatlas_api/structures/structure_tree.py
@@ -397,9 +397,6 @@ class StructureTree(SimpleTree):
 
         return [int(stid) for stid in path.split("/") if stid != ""]
 
-
-
-
     def print_structures(self, to_file=False, save_filepath=None):
         """ 
         Prints the name of every structure in the structure tree to the console.
@@ -409,9 +406,8 @@ class StructureTree(SimpleTree):
             where the tree structure will be saved.
         """
         names = [n["name"] for n in self.nodes()]
-        acronyms = [n["acronym"] for n in self.nodes()]        
-        
-        
+        acronyms = [n["acronym"] for n in self.nodes()]
+
         sort_idx = np.argsort(acronyms)
         acronyms, names = (
             np.array(acronyms)[sort_idx],
@@ -430,12 +426,10 @@ class StructureTree(SimpleTree):
                 raise ValueError(
                     f"save_filepath should point to a .txt file, not: {save_filepath}"
                 )
-            
-            with open(save_filepath, 'w') as out:
+
+            with open(save_filepath, "w") as out:
                 for a, n in zip(acronyms, names):
                     out.write("({}) - {}\n".format(a, n))
-
-
 
     def print_structures_tree(self, to_file=False, save_filepath=None):
         """
@@ -447,7 +441,9 @@ class StructureTree(SimpleTree):
                 where the tree structure will be saved.
         """
 
-        def add_descendants_to_tree(self, id_to_acronym_map, tree, structure_id, parent_id):
+        def add_descendants_to_tree(
+            self, id_to_acronym_map, tree, structure_id, parent_id
+        ):
             """
                 Recursively goes through all the the descendants of a region and adds them to the tree
             """
@@ -460,7 +456,9 @@ class StructureTree(SimpleTree):
 
             if len(descendants):
                 for child in descendants:
-                    add_descendants_to_tree(self, id_to_acronym_map, tree, child, structure_id)
+                    add_descendants_to_tree(
+                        self, id_to_acronym_map, tree, child, structure_id
+                    )
 
         # Create a Tree structure and initialise with root
         acronym_to_id_map = self.get_id_acronym_map()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_namespace_packages
 
-requirements = ["allensdk", "tqdm", "numpy", "tifffile"]
+requirements = ["tqdm", "numpy", "tifffile", "treelib"]
 
 
 setup(


### PR DESCRIPTION
Changes to `structures/simple_tree.py` and `structures/structure_tree.py`:

1. removed obsolete methods to remove dependency on allensdk
2. made most methods that expected and return a list more flexible, now you can pass a single item and they will return a single item
3. move `print_structures` and `print_structures_tree` from `core.Atlas` to `structures_structures_tree.py` to keep `Atlas` cleaner. 