### PR TITLE
Refactor tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ after_success:
 
 stages:
   - test
+  - name: deploy_test
+    if:
+      tag IS present
   - name: deploy
     if:
       tag IS present AND repo = brainglobe/brainatlas-api
+
 
 
 jobs:
@@ -69,6 +73,41 @@ jobs:
       before_install: source travis/install_unix.sh
       script: bash travis/lint.sh
 
+    - stage: deploy_test
+      name: "Windows Python 3.6"
+      language: shell
+      env: TRAVIS_PYTHON_VERSION=3.6
+      os: windows
+      before_install: source travis/install_windows.sh
+      script: bash travis/test.sh
+
+    - stage: deploy_test
+      name: "Windows Python 3.8"
+      language: shell
+      env: TRAVIS_PYTHON_VERSION=3.8
+      os: windows
+      before_install: source travis/install_windows.sh
+      script: bash travis/test.sh
+
+    - stage: deploy_test
+      name: "macOS Python 3.6"
+      os: osx
+      language: shell
+      env:
+      - TRAVIS_PYTHON_VERSION=3.6
+      - MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+      before_install: source travis/install_unix.sh
+      script: bash travis/test.sh
+
+    - stage: deploy_test
+      name: "macOS Python 3.8"
+      os: osx
+      language: shell
+      env:
+      - TRAVIS_PYTHON_VERSION=3.8
+      - MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+      before_install: source travis/install_unix.sh
+      script: bash travis/test.sh
 
     - stage: deploy
       os: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-after_success:
-  - pip install coveralls
-  - coveralls
-
 stages:
   - test
   - name: deploy_test
@@ -10,7 +6,6 @@ stages:
   - name: deploy
     if:
       tag IS present AND repo = brainglobe/brainatlas-api
-
 
 
 jobs:
@@ -24,6 +19,9 @@ jobs:
       python: 3.6
       before_install: source travis/install_unix.sh
       script: bash travis/test.sh
+      after_success:
+        - pip install coveralls
+        - coveralls
 
     - stage: test
       name: "Ubuntu Xenial python 3.7"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="brainatlas-api",
-    version="0.0.1c",
+    version="0.0.1d",
     description="A lightweight python module to interact with atlases for systems neuroscience",
     install_requires=requirements,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="brainatlas-api",
-    version="0.0.1d",
+    version="0.0.2rc0",
     description="A lightweight python module to interact with atlases for systems neuroscience",
     install_requires=requirements,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
             "coverage",
             "pre-commit",
             "PyMCubes",
-            "brainio",
         ]
     },
     python_requires=">=3.6, <3.8",


### PR DESCRIPTION
This PR:
* Removes a dependency specified twice (brainio).
* Only reports to coveralls on one test step, speeding up the tests (slightly) and 
prevents the linting step from submitting to coveralls (and incorrectly reporting 0% test coverage).
* Adds additional tests (macOS and Windows py36 & py38) that only run on tagged commits. So normally, only the 5 tests run, but when we want to make a release, the order for a tagged commit will be:
    * Normal tests
    * Additional tests for Windows and macOS to ensure no weird OS/Python version interaction. These tests will only run if the "normal" tests pass, so we can fail quicker. 
    * Deploy to PyPI, if and only if the first two steps pass. 

