### PR TITLE
list atlases

### DIFF
--- a/brainatlas_api/__init__.py
+++ b/brainatlas_api/__init__.py
@@ -7,4 +7,14 @@ available_atlases = [
 
 
 def get_atlas_class_from_name(name):
-    a = 1
+    names = [
+        f"{atlas.atlas_name}_v{atlas.version}" for atlas in available_atlases
+    ]
+    atlases = {n: a for n, a in zip(names, available_atlases)}
+
+    if name in atlases.keys():
+        return atlases[name]
+    else:
+        print(f"Could not find atlas with name {name}. Available atlases:\n")
+        list_atlases()
+        return None

--- a/brainatlas_api/__init__.py
+++ b/brainatlas_api/__init__.py
@@ -1,0 +1,1 @@
+from brainatlas_api.list_atlases import list_atlases

--- a/brainatlas_api/__init__.py
+++ b/brainatlas_api/__init__.py
@@ -1,1 +1,10 @@
+from brainatlas_api import bg_atlas
 from brainatlas_api.list_atlases import list_atlases
+
+available_atlases = [
+    cls for cls in map(bg_atlas.__dict__.get, bg_atlas.__all__)
+]
+
+
+def get_atlas_class_from_name(name):
+    a = 1

--- a/brainatlas_api/bg_atlas.py
+++ b/brainatlas_api/bg_atlas.py
@@ -8,6 +8,8 @@ from brainatlas_api import core
 
 COMPRESSED_FILENAME = "atlas.tar.gz"
 
+__all__ = ["FishAtlas", "RatAtlas", "AllenBrain25Um", "AllenHumanBrain500Um"]
+
 
 class BrainGlobeAtlas(core.Atlas):
     """Add download functionalities to Atlas class.

--- a/brainatlas_api/list_atlases.py
+++ b/brainatlas_api/list_atlases.py
@@ -3,13 +3,7 @@ from rich.table import Table
 from rich import print as rprint
 
 from brainatlas_api import config
-from brainatlas_api.bg_atlas import (
-    BrainGlobeAtlas,
-    FishAtlas,
-    RatAtlas,
-    AllenBrain25Um,
-    AllenHumanBrain500Um,
-)
+from brainatlas_api import bg_atlas
 
 
 """
@@ -29,17 +23,22 @@ def list_atlases():
             atlases[elem.name] = dict(
                 downloaded=True,
                 local=str(elem),
-                online=BrainGlobeAtlas._remote_url_base.format(elem.name),
+                online=bg_atlas.BrainGlobeAtlas._remote_url_base.format(
+                    elem.name
+                ),
             )
 
     # ---------------------- Get atlases not yet downloaded ---------------------- #
-    for atlas in [FishAtlas, RatAtlas, AllenBrain25Um, AllenHumanBrain500Um]:
+    available_atlases = [
+        cls for cls in map(bg_atlas.__dict__.get, bg_atlas.__all__)
+    ]
+    for atlas in available_atlases:
         name = f"{atlas.atlas_name}_v{atlas.version}"
         if name not in atlases.keys():
             atlases[str(name)] = dict(
                 downloaded=False,
                 local="[red]---[/red]",
-                online=BrainGlobeAtlas._remote_url_base.format(name),
+                online=atlas._remote_url_base.format(name),
             )
 
     # -------------------------------- print table ------------------------------- #

--- a/brainatlas_api/list_atlases.py
+++ b/brainatlas_api/list_atlases.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from rich.table import Table
+from rich import print as rprint
+
+from brainatlas_api import config
+from brainatlas_api.bg_atlas import (
+    BrainGlobeAtlas,
+    FishAtlas,
+    RatAtlas,
+    AllenBrain25Um,
+    AllenHumanBrain500Um,
+)
+
+
+"""
+    Some functionality to list all available and downloaded brainglobe atlases
+"""
+
+
+def list_atlases():
+    # Parse config
+    conf = config.read_config()
+    brainglobe_dir = Path(conf["default_dirs"]["brainglobe_dir"])
+
+    # ----------------------------- Get local atlases ---------------------------- #
+    atlases = {}
+    for elem in brainglobe_dir.iterdir():
+        if elem.is_dir():
+            atlases[elem.name] = dict(
+                downloaded=True,
+                local=str(elem),
+                online=BrainGlobeAtlas._remote_url_base.format(elem.name),
+            )
+
+    # ---------------------- Get atlases not yet downloaded ---------------------- #
+    for atlas in [FishAtlas, RatAtlas, AllenBrain25Um, AllenHumanBrain500Um]:
+        name = f"{atlas.atlas_name}_v{atlas.version}"
+        if name not in atlases.keys():
+            atlases[str(name)] = dict(
+                downloaded=False,
+                local="[red]---[/red]",
+                online=BrainGlobeAtlas._remote_url_base.format(name),
+            )
+
+    # -------------------------------- print table ------------------------------- #
+    table = Table(
+        show_header=True,
+        header_style="bold green",
+        title="\n\nBrainglobe Atlases",
+    )
+    table.add_column("Name")
+    table.add_column("Downloaded")
+    table.add_column("Local path")
+    table.add_column("Online path", style="dim")
+
+    for atlas, info in atlases.items():
+        if info["downloaded"]:
+            downloaded = "[green]:heavy_check_mark:[/green]"
+        else:
+            downloaded = "[red]---[/red]"
+        table.add_row(
+            "[b]" + atlas + "[/b]", downloaded, info["local"], info["online"]
+        )
+
+    rprint(table)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas
 requests
 meshio
 click
+rich

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     python_requires=">=3.6, <3.8",
     entry_points={
         "console_scripts": [
-            "brainatlas_config = brainatlas_api.config:cli_modify_config"
+            "brainatlas_config = brainatlas_api.config:cli_modify_config",
+            "brainatlas_list_atlases = brainatlas_api.list_atlases:list_atlases",
         ]
     },
     packages=find_namespace_packages(exclude=("atlas_gen", "docs", "tests*")),

--- a/tests/test_list_atlases.py
+++ b/tests/test_list_atlases.py
@@ -3,3 +3,13 @@ import brainatlas_api
 
 def test_list_atlases():
     brainatlas_api.list_atlases()
+
+
+def test_get_atlas_from_name():
+    a1 = brainatlas_api.get_atlas_class_from_name("allen_mouse_25um_v0.2")
+    a2 = brainatlas_api.get_atlas_class_from_name("xxxx")
+
+    if a1 is None:
+        raise ValueError
+    if a2 is not None:
+        raise ValueError

--- a/tests/test_list_atlases.py
+++ b/tests/test_list_atlases.py
@@ -1,0 +1,5 @@
+import brainatlas_api
+
+
+def test_list_atlases():
+    brainatlas_api.list_atlases()


### PR DESCRIPTION
This PR introduces functionality to list all available and downloaded brainglobe atlases, these get printed to console as such:
<img width="1107" alt="image" src="https://user-images.githubusercontent.com/17436313/84704842-5b2bd600-af52-11ea-8125-f6ddfa3a2317.png">


this can be done by either calling `brainatlas_list_atlases` in the terminal or with:
```
import brainglobe_api
brainglobe_api.list_atlases()
```

**limitation**: currently the list of 'available' atlases is specified manually and it uses the classes defined in `brainglobe_api.bg_atlas.py`, it would be nicer to have a more automated way of doing this. 