### PR TITLE
Atlas version control - first draft

### DIFF
--- a/atlas_gen/wrapup.py
+++ b/atlas_gen/wrapup.py
@@ -19,7 +19,7 @@ from brainatlas_api import descriptors
 
 # This should be changed every time we make changes in the atlas
 # structure:
-ATLAS_VERSION = 0
+ATLAS_VERSION = descriptors.ATLAS_MAJOR_V
 
 
 def wrapup_atlas_from_data(

--- a/brainatlas_api/__init__.py
+++ b/brainatlas_api/__init__.py
@@ -8,7 +8,8 @@ available_atlases = [
 
 def get_atlas_class_from_name(name):
     names = [
-        f"{atlas.atlas_name}_v{atlas.version}" for atlas in available_atlases
+        f"{atlas.atlas_name}_v{atlas.local_version}"
+        for atlas in available_atlases
     ]
     atlases = {n: a for n, a in zip(names, available_atlases)}
 

--- a/brainatlas_api/__init__.py
+++ b/brainatlas_api/__init__.py
@@ -7,10 +7,8 @@ available_atlases = [
 
 
 def get_atlas_class_from_name(name):
-    names = [
-        f"{atlas.atlas_name}_v{atlas.local_version}"
-        for atlas in available_atlases
-    ]
+    names = [atlas.atlas_name for atlas in available_atlases]
+
     atlases = {n: a for n, a in zip(names, available_atlases)}
 
     if name in atlases.keys():

--- a/brainatlas_api/bg_atlas.py
+++ b/brainatlas_api/bg_atlas.py
@@ -35,7 +35,6 @@ class BrainGlobeAtlas(core.Atlas):
         """
 
     atlas_name = None
-    _minor_v = None
     _remote_url_base = (
         "https://gin.g-node.org/brainglobe/atlases/raw/master/{}"
     )
@@ -57,9 +56,6 @@ class BrainGlobeAtlas(core.Atlas):
             dir_path = Path(dir)
             dir_path.mkdir(exist_ok=True)
             setattr(self, dirname, dir_path)
-
-        # Flag for existence of local version, will be toggled if one is found.
-        self._exists_local = False
 
         # Look for this atlas in local brainglobe folder:
         if self.local_full_name is None:

--- a/brainatlas_api/descriptors.py
+++ b/brainatlas_api/descriptors.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+# Major version of atlases used by current brainatlas-api release:
+ATLAS_MAJOR_V = 0
+
 # Entries and types from this template will be used to check atlas info
 # consistency. Please keep updated both this and the function when changing
 # the structure.
@@ -16,6 +19,8 @@ METADATA_TEMPLATE = {
     "supplementary_stacks": [],
 }
 
+
+# Template for a structure dictionary:
 STRUCTURE_TEMPLATE = {
     "acronym": "root",
     "id": 997,
@@ -25,6 +30,7 @@ STRUCTURE_TEMPLATE = {
 }
 
 
+# File and directory names for the atlas package:
 METADATA_FILENAME = "metadata.json"
 STRUCTURES_FILENAME = "structures.json"
 REFERENCE_FILENAME = "reference.tiff"
@@ -32,9 +38,10 @@ ANNOTATION_FILENAME = "annotation.tiff"
 HEMISPHERES_FILENAME = "hemispheres.tiff"
 MESHES_DIRNAME = "meshes"
 
+# Types for the atlas stacks:
 REFERENCE_DTYPE = np.uint16
 ANNOTATION_DTYPE = np.uint32
 HEMISPHERES_DTYPE = np.uint8
 
-# Standard orientation origin: Anterior, Left, Superior
+# Standard orientation origin: Anterior, Left, Superior (using BGSpace definition)
 ATLAS_ORIENTATION = "asl"

--- a/brainatlas_api/list_atlases.py
+++ b/brainatlas_api/list_atlases.py
@@ -33,7 +33,7 @@ def list_atlases():
         cls for cls in map(bg_atlas.__dict__.get, bg_atlas.__all__)
     ]
     for atlas in available_atlases:
-        name = f"{atlas.atlas_name}_v{atlas.version}"
+        name = f"{atlas.atlas_name}_v{atlas.local_version}"
         if name not in atlases.keys():
             atlases[str(name)] = dict(
                 downloaded=False,

--- a/brainatlas_api/utils.py
+++ b/brainatlas_api/utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import requests
 from tqdm.auto import tqdm
 import logging
+import configparser
 
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
@@ -28,7 +29,7 @@ def check_internet_connection(
         if not raise_error:
             print("No internet connection available.")
         else:
-            raise ValueError(
+            raise ConnectionError(
                 "No internet connection, try again when you are connected to the internet."
             )
     return False
@@ -54,6 +55,14 @@ def retrieve_over_http(url, output_file_path):
         raise requests.exceptions.ConnectionError(
             f"Could not download file from {url}"
         )
+
+
+def conf_from_url(url):
+    text = requests.get(url).text
+    config = configparser.ConfigParser()
+    config.read_string(text)
+
+    return config
 
 
 # --------------------------------- File I/O --------------------------------- #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,11 @@ from brainatlas_api.bg_atlas import ExampleAtlas
 # import tempfile
 
 
+@pytest.fixture()
+def atlas():
+    return ExampleAtlas()
+
+
 @pytest.fixture(scope="module")
 def atlas_path():
     # brainglobe_path=tempfile.mkdtemp()

--- a/tests/test_bg_atlas.py
+++ b/tests/test_bg_atlas.py
@@ -1,0 +1,30 @@
+import pytest
+import tempfile
+import shutil
+from brainatlas_api.bg_atlas import ExampleAtlas
+
+
+def test_versions(atlas):
+    assert atlas.local_version == atlas.remote_version
+
+
+def test_local_search():
+    brainglobe_dir = tempfile.mkdtemp()
+    interm_download_dir = tempfile.mkdtemp()
+
+    atlas = ExampleAtlas(
+        brainglobe_dir=brainglobe_dir, interm_download_dir=interm_download_dir
+    )
+
+    assert atlas.atlas_name in atlas.local_full_name
+
+    # Make a copy:
+    copy_filename = atlas.root_dir.parent / (atlas.root_dir.name + "_2")
+    shutil.copytree(atlas.root_dir, copy_filename)
+
+    with pytest.raises(FileExistsError) as error:
+        _ = ExampleAtlas(brainglobe_dir=brainglobe_dir)
+    assert "Multiple versions of atlas" in str(error)
+
+    shutil.rmtree(brainglobe_dir)
+    shutil.rmtree(interm_download_dir)

--- a/tests/test_core_atlas.py
+++ b/tests/test_core_atlas.py
@@ -2,13 +2,6 @@ import pytest
 
 import numpy as np
 
-from brainatlas_api.bg_atlas import ExampleAtlas
-
-
-@pytest.fixture()
-def atlas():
-    return ExampleAtlas()
-
 
 def test_initialization(atlas):
     assert atlas.metadata == {
@@ -69,10 +62,15 @@ def test_meshfile_from_id(atlas):
         atlas.meshfile_from_structure("CH")
         == atlas.root_dir / "meshes/567.obj"
     )
+    assert atlas.root_meshfile() == atlas.root_dir / "meshes/997.obj"
 
 
 def test_mesh_from_id(atlas):
-    # TODO will change depending on mesh loading package
     mesh = atlas.structures[567]["mesh"]
     assert np.allclose(mesh.points[0], [8019.52, 3444.48, 507.104])
-    assert np.allclose(mesh.cells[0].data[0], [0, 1, 2])
+
+    mesh = atlas.mesh_from_structure(567)
+    assert np.allclose(mesh.points[0], [8019.52, 3444.48, 507.104])
+
+    mesh = atlas.root_mesh()
+    assert np.allclose(mesh.points[0], [7896.56, 3384.15, 503.781])

--- a/tests/test_list_atlases.py
+++ b/tests/test_list_atlases.py
@@ -1,15 +1,17 @@
 import brainatlas_api
+import pytest
 
 
 def test_list_atlases():
     brainatlas_api.list_atlases()
 
 
-def test_get_atlas_from_name():
-    a1 = brainatlas_api.get_atlas_class_from_name("allen_mouse_25um_v0.2")
-    a2 = brainatlas_api.get_atlas_class_from_name("xxxx")
-
-    if a1 is None:
-        raise ValueError
-    if a2 is not None:
-        raise ValueError
+@pytest.mark.parametrize(
+    "key, is_none", [("allen_mouse_25um", False), ("xxx", True)]
+)
+def test_get_atlas_from_name(key, is_none):
+    a = brainatlas_api.get_atlas_class_from_name(key)
+    if is_none:
+        assert a is None
+    else:
+        assert a is not None


### PR DESCRIPTION
We still lack a way of properly addressing local vs. remote atlases versions, which might be important to tackle consistently from the beginning (related to #10 ).

I made a draft of some changes to the BGAtlas class, so that:
 - there is no more `self.version` attribute defined manually in the class;
 - major version is determined from a global descriptor in the descriptors module. If at any point something changes in brainatlas-api which is no more back-compatible with older atlases, this should be increased;
 - most recent available minor version is determined from an heuristic search on the GIN urls (try urls with different versions and find the one that produces a correct page response). I truly think that something like this would be important - having reference to the most recent remote version of the atlas - but the current approach has some drawbacks:
      * it is ugly;
      * it is slow (about 250-300 ms per request, which - with a break - would mean about 1-2 sec every time we instantiate an Atlas object);
So I am happy to hear any input/other approaches. One option could potentially be refactor what now was the self.version into a `self.most_recent_version` and refer to that instead of using this search, under the assumption that we the curators always keep these numbers in good synch.  Let me know what you think on this point
- If local major version is behind minimal required major version, an error is raised; if local minor version is behind last available minor version for the atlas, a warning is raised. 

I would now add an option to pass in the init to automatically remove the old atlas and download a newer one, if available. This might also solve the speed problem I raised above, making the control happening only if a `check_updates` argument is passed in the class constructor